### PR TITLE
fix bug in scripts/data_process/process_amass_db.py

### DIFF
--- a/scripts/data_process/process_amass_db.py
+++ b/scripts/data_process/process_amass_db.py
@@ -224,7 +224,7 @@ def process_qpos_list(qpos_list):
 
 
 amass_splits = {
-    'vald': ['HumanEva', 'MPI_HDM05', 'SFU', 'MPI_mosh'],
+    'valid': ['HumanEva', 'MPI_HDM05', 'SFU', 'MPI_mosh'],
     'test': ['Transitions_mocap', 'SSM_synced'],
     'train': ['CMU', 'MPI_Limits', 'TotalCapture', 'Eyes_Japan_Dataset', 'KIT', 'BML', 'EKUT', 'TCD_handMocap', "BMLhandball", "DanceDB", "ACCAD", "BMLmovi", "BioMotionLab", "Eyes", "DFaust"]  # Adding ACCAD
 }


### PR DESCRIPTION
Hi !

AMASS trainset has 11313 samples, validset has 347 samples. The bug unexpectedly resulted in a trainset pkl file with 11313+347=11660 samples, and a validset pkl file with 0 sample.