### PR TITLE
better show results in tensorboard

### DIFF
--- a/phc/learning/amp_agent.py
+++ b/phc/learning/amp_agent.py
@@ -904,32 +904,36 @@ class AMPAgent(common_agent.CommonAgent):
         if "disc_loss" in train_info:
             disc_reward_std, disc_reward_mean = torch.std_mean(train_info['disc_rewards'])
             train_info_dict.update({
-                "disc_loss": torch_ext.mean_list(train_info['disc_loss']).item(),
-                "disc_agent_acc": torch_ext.mean_list(train_info['disc_agent_acc']).item(),
-                "disc_demo_acc": torch_ext.mean_list(train_info['disc_demo_acc']).item(),
-                "disc_agent_logit": torch_ext.mean_list(train_info['disc_agent_logit']).item(),
-                "disc_demo_logit": torch_ext.mean_list(train_info['disc_demo_logit']).item(),
-                "disc_grad_penalty": torch_ext.mean_list(train_info['disc_grad_penalty']).item(),
-                "disc_logit_loss": torch_ext.mean_list(train_info['disc_logit_loss']).item(),
-                "disc_reward_mean": disc_reward_mean.item(),
-                "disc_reward_std": disc_reward_std.item(),
+                "disc/loss": torch_ext.mean_list(train_info['disc_loss']).item(),
+                "disc/agent_acc": torch_ext.mean_list(train_info['disc_agent_acc']).item(),
+                "disc/demo_acc": torch_ext.mean_list(train_info['disc_demo_acc']).item(),
+                "disc/agent_logit": torch_ext.mean_list(train_info['disc_agent_logit']).item(),
+                "disc/demo_logit": torch_ext.mean_list(train_info['disc_demo_logit']).item(),
+                "disc/grad_penalty": torch_ext.mean_list(train_info['disc_grad_penalty']).item(),
+                "disc/logit_loss": torch_ext.mean_list(train_info['disc_logit_loss']).item(),
+                "disc/reward_mean": disc_reward_mean.item(),
+                "disc/reward_std": disc_reward_std.item(),
             })
         
         if "returns" in train_info:
-            train_info_dict['returns'] = train_info['returns'].mean().item()
+            train_info_dict['rewards/returns'] = train_info['returns'].mean().item()
             
         if "mb_rewards" in train_info:
-            train_info_dict['mb_rewards'] = train_info['mb_rewards'].mean().item()
+            train_info_dict['rewards/mb_rewards'] = train_info['mb_rewards'].mean().item()
         
         # if 'terminated_flags' in train_info:
         #     train_info_dict["success_rate"] =  1 - torch.mean((train_info['terminated_flags'] > 0).float()).item()
         
         if "reward_raw" in train_info:
-            for idx, v in enumerate(train_info['reward_raw'].cpu().numpy().tolist()):
-                train_info_dict[f"ind_reward.{idx}"] =  v
+            reward_raw=train_info['reward_raw'].cpu().numpy().tolist()
+            train_info_dict["rewards/body_pos"] =  reward_raw[0]
+            train_info_dict["rewards/body_rot"] =  reward_raw[1]
+            train_info_dict["rewards/lin_vel"] =  reward_raw[2]
+            train_info_dict["rewards/ang_vel"] =  reward_raw[3]
+            train_info_dict["rewards/power"] =  reward_raw[4]
         
         if "sym_loss" in train_info:
-            train_info_dict['sym_loss'] = torch_ext.mean_list(train_info['sym_loss']).item()
+            train_info_dict['loss/sym_loss'] = torch_ext.mean_list(train_info['sym_loss']).item()
         return train_info_dict
 
     def _amp_debug(self, info):

--- a/phc/learning/common_agent.py
+++ b/phc/learning/common_agent.py
@@ -136,7 +136,7 @@ class CommonAgent(a2c_continuous.A2CAgent):
 
                 self.writer.add_scalar('performance/total_fps', curr_frames / scaled_time, frame)
                 self.writer.add_scalar('performance/step_fps', curr_frames / scaled_play_time, frame)
-                self.writer.add_scalar('info/epochs', epoch_num, frame)
+                self.writer.add_scalar('episode_lengths/epochs', epoch_num, frame)
                 train_info_dict = self._assemble_train_info(train_info, frame)
                 self.algo_observer.after_print_stats(frame, epoch_num, total_time)
                 if self.save_freq > 0:
@@ -165,7 +165,7 @@ class CommonAgent(a2c_continuous.A2CAgent):
                         eval_info = self.eval()
                         train_info_dict.update(eval_info)
                     
-                    train_info_dict.update({"episode_lengths": mean_lengths, "mean_rewards": np.mean(mean_rewards)})
+                    train_info_dict.update({"episode_lengths/episode_lengths": mean_lengths, "rewards/mean_rewards": np.mean(mean_rewards)})
                     self._log_train_info(train_info_dict, frame)
 
                     epoch_end = time.time()
@@ -603,22 +603,22 @@ class CommonAgent(a2c_continuous.A2CAgent):
     
     def _assemble_train_info(self, train_info, frame):
         train_info_dict = {
-            "update_time": train_info['update_time'],
-            "play_time": train_info['play_time'],
-            "last_lr": train_info['last_lr'][-1] * train_info['lr_mul'][-1],
-            "lr_mul": train_info['lr_mul'][-1],
-            "e_clip": self.e_clip * train_info['lr_mul'][-1],
+            "performance/update_time": train_info['update_time'],
+            "performance/play_time": train_info['play_time'],
+            "learning_rate/last_lr": train_info['last_lr'][-1] * train_info['lr_mul'][-1],
+            "learning_rate/lr_mul": train_info['lr_mul'][-1],
+            "learning_rate/e_clip": self.e_clip * train_info['lr_mul'][-1],
         }
         
         if "actor_loss" in train_info:
             train_info_dict.update(
                 {
-                    "a_loss": torch_ext.mean_list(train_info['actor_loss']).item(),
-                    "c_loss": torch_ext.mean_list(train_info['critic_loss']).item(),
-                    "bounds_loss": torch_ext.mean_list(train_info['b_loss']).item(),
-                    "entropy": torch_ext.mean_list(train_info['entropy']).item(),
-                    "clip_frac": torch_ext.mean_list(train_info['actor_clip_frac']).item(),
-                    "kl": torch_ext.mean_list(train_info['kl']).item(),
+                    "loss/actor_loss": torch_ext.mean_list(train_info['actor_loss']).item(),
+                    "loss/critic_loss": torch_ext.mean_list(train_info['critic_loss']).item(),
+                    "loss/bounds_loss": torch_ext.mean_list(train_info['b_loss']).item(),
+                    "loss/entropy": torch_ext.mean_list(train_info['entropy']).item(),
+                    "loss/clip_frac": torch_ext.mean_list(train_info['actor_clip_frac']).item(),
+                    "loss/kl": torch_ext.mean_list(train_info['kl']).item(),
                 }
             )
         
@@ -738,7 +738,7 @@ class CommonDiscreteAgent(a2c_discrete.DiscreteA2CAgent):
 
                 self.writer.add_scalar('performance/total_fps', curr_frames / scaled_time, frame)
                 self.writer.add_scalar('performance/step_fps', curr_frames / scaled_play_time, frame)
-                self.writer.add_scalar('info/epochs', epoch_num, frame)
+                self.writer.add_scalar('episode_lengths/epochs', epoch_num, frame)
                 train_info_dict = self._assemble_train_info(train_info, frame)
                 self.algo_observer.after_print_stats(frame, epoch_num, total_time)
                 if self.save_freq > 0:
@@ -1085,16 +1085,16 @@ class CommonDiscreteAgent(a2c_discrete.DiscreteA2CAgent):
     
     def _assemble_train_info(self, train_info, frame):
         train_info_dict = {
-            "update_time": train_info['update_time'],
-            "play_time": train_info['play_time'],
-            "a_loss": torch_ext.mean_list(train_info['actor_loss']).item(),
-            "c_loss": torch_ext.mean_list(train_info['critic_loss']).item(),
-            "entropy": torch_ext.mean_list(train_info['entropy']).item(),
-            "last_lr": train_info['last_lr'][-1] * train_info['lr_mul'][-1],
-            "lr_mul": train_info['lr_mul'][-1],
-            "e_clip": self.e_clip * train_info['lr_mul'][-1],
-            "clip_frac": torch_ext.mean_list(train_info['actor_clip_frac']).item(),
-            "kl": torch_ext.mean_list(train_info['kl']).item(),
+            "performance/update_time": train_info['update_time'],
+            "performance/play_time": train_info['play_time'],
+            "loss/actor_loss": torch_ext.mean_list(train_info['actor_loss']).item(),
+            "loss/critic_loss": torch_ext.mean_list(train_info['critic_loss']).item(),
+            "loss/entropy": torch_ext.mean_list(train_info['entropy']).item(),
+            "learning_rate/last_lr": train_info['last_lr'][-1] * train_info['lr_mul'][-1],
+            "learning_rate/lr_mul": train_info['lr_mul'][-1],
+            "learning_rate/e_clip": self.e_clip * train_info['lr_mul'][-1],
+            "loss/clip_frac": torch_ext.mean_list(train_info['actor_clip_frac']).item(),
+            "loss/kl": torch_ext.mean_list(train_info['kl']).item(),
         }
         
         return train_info_dict

--- a/phc/learning/im_amp.py
+++ b/phc/learning/im_amp.py
@@ -330,14 +330,14 @@ class IMAmpAgent(amp_agent.AMPAgent):
                 end = True
                 
                 eval_info = {
-                    "eval_success_rate": self.success_rate,
-                    "eval_mpjpe_all": metrics_all_print['mpjpe_g'],
-                    "eval_mpjpe_succ": metrics_succ_print['mpjpe_g'],
-                    "accel_dist": metrics_succ_print['accel_dist'], 
-                    "vel_dist": metrics_succ_print['vel_dist'], 
-                    "mpjpel_all": metrics_all_print['mpjpe_l'],
-                    "mpjpel_succ": metrics_succ_print['mpjpe_l'],
-                    "mpjpe_pa": metrics_succ_print['mpjpe_pa'], 
+                    "eval/success_rate": self.success_rate,
+                    "eval/mpjpe_all": metrics_all_print['mpjpe_g'],
+                    "eval/mpjpe_succ": metrics_succ_print['mpjpe_g'],
+                    "eval/accel_dist": metrics_succ_print['accel_dist'], 
+                    "eval/vel_dist": metrics_succ_print['vel_dist'], 
+                    "eval/mpjpel_all": metrics_all_print['mpjpe_l'],
+                    "eval/mpjpel_succ": metrics_succ_print['mpjpe_l'],
+                    "eval/mpjpe_pa": metrics_succ_print['mpjpe_pa'], 
                 }
                 # failed_keys = humanoid_env._motion_lib._motion_data_keys[terminate_hist[:humanoid_env._motion_lib._num_unique_motions]]
                 # success_keys = humanoid_env._motion_lib._motion_data_keys[~terminate_hist[:humanoid_env._motion_lib._num_unique_motions]]

--- a/scripts/data_process/fit_smpl_shape.py
+++ b/scripts/data_process/fit_smpl_shape.py
@@ -33,10 +33,7 @@ from tqdm import tqdm
 @hydra.main(version_base=None, config_path="../../phc/data/cfg", config_name="config")
 def main(cfg : DictConfig) -> None:
     
-    robot_name = "h1"
     humanoid_fk = Humanoid_Batch(cfg.robot) # load forward kinematics model
-
-    robot_joint_names = humanoid_fk.body_names
 
     #### Define corresonpdances between h1 and smpl joints
     robot_joint_names_augment = humanoid_fk.body_names_augment 
@@ -69,16 +66,18 @@ def main(cfg : DictConfig) -> None:
     offset = joints[:, 0] - trans
     root_trans_offset = trans + offset
 
-    fk_return = humanoid_fk.fk_batch(pose_aa_robot[None, ], root_trans_offset[None, 0:1])
+    fk_return = humanoid_fk.fk_batch(pose_aa_robot[None, ], root_trans_offset[None, 0:1]) # humanoid shape
     
 
     shape_new = Variable(torch.zeros([1, 10]).to(device), requires_grad=True)
     scale = Variable(torch.ones([1]).to(device), requires_grad=True)
     optimizer_shape = torch.optim.Adam([shape_new, scale],lr=0.1)
     
-    pbar = tqdm(range(1000))
+    train_iterations=3000
+    print("start fitting shapes")
+    pbar = tqdm(range(train_iterations))
     for iteration in pbar:
-        verts, joints = smpl_parser_n.get_joints_verts(pose_aa_stand, shape_new, trans[0:1])
+        verts, joints = smpl_parser_n.get_joints_verts(pose_aa_stand, shape_new, trans[0:1]) # fitted smpl shape
         root_pos = joints[:, 0]
         joints = (joints - joints[:, 0]) * scale + root_pos
         if len(cfg.robot.extend_config) > 0:
@@ -86,27 +85,34 @@ def main(cfg : DictConfig) -> None:
         else:
             diff = fk_return.global_translation[:, :, robot_joint_pick_idx] - joints[:, smpl_joint_pick_idx]
 
-        loss_g = diff.norm(dim = -1).mean() 
+        # loss_g = diff.norm(dim = -1).mean() 
+        loss_g = diff.norm(dim = -1).square().sum()
+        
         loss = loss_g
         pbar.set_description_str(f"{iteration} - Loss: {loss.item() * 1000}")
 
         optimizer_shape.zero_grad()
         loss.backward()
         optimizer_shape.step()
+
+    # print the fitted shape and scale parameters
+    print("shape:",shape_new.detach())
+    print("scale:",scale)
+
     if cfg.get("vis", False):
         from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 unused import
         import matplotlib.pyplot as plt
         
-        j3d = fk_return.global_translation_extend[0, :, :, :].detach().numpy()
+        j3d = fk_return.global_translation_extend[0, :, robot_joint_pick_idx, :].detach().numpy()
         j3d = j3d - j3d[:, 0:1]
-        j3d_joints = joints.detach().numpy()
+        j3d_joints = joints[:, smpl_joint_pick_idx].detach().numpy()
         j3d_joints = j3d_joints - j3d_joints[:, 0:1]
         idx = 0
         fig = plt.figure()
         ax = fig.add_subplot(111, projection='3d')
         ax.view_init(90, 0)
-        ax.scatter(j3d[idx, :,0], j3d[idx, :,1], j3d[idx, :,2])
-        ax.scatter(j3d_joints[idx, :,0], j3d_joints[idx, :,1], j3d_joints[idx, :,2])
+        ax.scatter(j3d[idx, :,0], j3d[idx, :,1], j3d[idx, :,2], label='Humanoid Shape', c='blue')
+        ax.scatter(j3d_joints[idx, :,0], j3d_joints[idx, :,1], j3d_joints[idx, :,2], label='Fitted Shape', c='red')
 
         ax.set_xlabel('X Label')
         ax.set_ylabel('Y Label')
@@ -115,6 +121,7 @@ def main(cfg : DictConfig) -> None:
         ax.set_xlim(-drange, drange)
         ax.set_ylim(-drange, drange)
         ax.set_zlim(-drange, drange)
+        ax.legend()
         plt.show()
 
     os.makedirs(f"data/{cfg.robot.humanoid_type}", exist_ok=True)


### PR DESCRIPTION
We can use disc/loss,  disc/agent_acc,.etc instead of disc_loss, disc_agent_acc. By doing so, these results will show in one group in tensorboard. This increases simplicity when checking the training results.

Also optimize the imitate rewards.
```
if "reward_raw" in train_info:
    reward_raw=train_info['reward_raw'].cpu().numpy().tolist()
    train_info_dict["rewards/body_pos"] =  reward_raw[0]
    train_info_dict["rewards/body_rot"] =  reward_raw[1]
    train_info_dict["rewards/lin_vel"] =  reward_raw[2]
    train_info_dict["rewards/ang_vel"] =  reward_raw[3]
    train_info_dict["rewards/power"] =  reward_raw[4]
```


